### PR TITLE
스터디모집 정보를 토대로한 스터디룸, 스터디멤버 생성 기능 구현

### DIFF
--- a/src/main/java/com/studit/backend/domain/recruit/controller/StudyRecruitController.java
+++ b/src/main/java/com/studit/backend/domain/recruit/controller/StudyRecruitController.java
@@ -13,8 +13,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/recruits")
@@ -32,7 +30,10 @@ public class StudyRecruitController {
         // JWT 에서 userId 추출
         Long leaderId = jwtTokenProvider.getUserIdFromToken(token);
 
-        studyRecruitService.createRecruit(request, leaderId);
+        Long recruitId = studyRecruitService.createRecruit(request, leaderId);
+
+        // 모집 종료 시 자동으로 스터디룸이 생성되도록 예약 등록
+        studyRecruitService.scheduleCreateRoom(recruitId);
 
         return ResponseEntity.ok("모집글이 생성되었습니다.");
     }

--- a/src/main/java/com/studit/backend/domain/recruit/entity/StudyRecruit.java
+++ b/src/main/java/com/studit/backend/domain/recruit/entity/StudyRecruit.java
@@ -18,30 +18,44 @@ import java.util.List;
 @Builder
 @Table(name = "study_recruits")
 public class StudyRecruit {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "recruit_id")
     private Long id; // 모집 ID
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "leader_id")
+    @JoinColumn(name = "leader_id", nullable = false)
     private User leader; // 모집자 ID (스터디장)
 
+    @Column(name = "title", nullable = false, length = 255)
     private String title; // 모집제목
+
+    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
     private String description; // 모집설명
+
+    @Column(name = "tags", length = 255)
     private String tags; // 태그(검색용)
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
     private StudyCategory category; // 카테고리 (코딩, 공무원 등)
 
+    @Column(name = "goal_time", nullable = false, updatable = false)
     private Integer goalTime; // 총 목표시간
+
+    @Column(name = "deposit", nullable = false, updatable = false)
     private Integer deposit; // 예치금
+
+    @Column(name = "max_members", nullable = false)
     private Integer maxMembers; // 최대 인원수
 
+    @Column(name = "study_start_at", nullable = false, updatable = false)
     private LocalDateTime studyStartAt; // 스터디 시작일
+
+    @Column(name = "study_end_at", nullable = false, updatable = false)
     private LocalDateTime studyEndAt; // 스터디 종료일
 
+    @Column(name = "recruit_start_at", nullable = false, updatable = false)
     private LocalDateTime recruitStartAt; // 모집 시작일
     @PrePersist
     public void prePersist() {
@@ -50,13 +64,20 @@ public class StudyRecruit {
         }
     }
 
+    @Column(name = "recruit_end_at", nullable = false, updatable = false)
     private LocalDateTime recruitEndAt; // 모집 종료일
 
     @Builder.Default
     @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
     private RecruitStatus status = RecruitStatus.ACTIVE; // 모집 상태 (ACTIVE, DELETED, COMPLETED 등)
 
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt; // 최종수정일
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
 
     @OneToMany(mappedBy = "studyRecruit", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StudyRegister> studyRegisters; // 가입자 리스트

--- a/src/main/java/com/studit/backend/domain/recruit/entity/StudyRegister.java
+++ b/src/main/java/com/studit/backend/domain/recruit/entity/StudyRegister.java
@@ -22,17 +22,19 @@ public class StudyRegister {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "recruit_id")
+    @JoinColumn(name = "recruit_id", nullable = false)
     private StudyRecruit studyRecruit;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Builder.Default
     @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
     private RegisterStatus status = RegisterStatus.REGISTER;
 
+    @Column(name = "register_at", nullable = false, updatable = false)
     private LocalDateTime registerAt;
     @PrePersist
     public void prePersist() {

--- a/src/main/java/com/studit/backend/domain/recruit/repository/StudyRegisterRepository.java
+++ b/src/main/java/com/studit/backend/domain/recruit/repository/StudyRegisterRepository.java
@@ -15,4 +15,5 @@ public interface StudyRegisterRepository extends JpaRepository<StudyRegister, Lo
     int countByStudyRecruitAndStatus(StudyRecruit studyRecruit, RegisterStatus status);
     List<StudyRegister> findByStudyRecruit(StudyRecruit studyRecruit);
     Optional<StudyRegister> findByStudyRecruitIdAndUserId(Long recruitId, Long userId);
+    boolean existsByStudyRecruitAndUser(StudyRecruit studyRecruit, User user);
 }

--- a/src/main/java/com/studit/backend/domain/recruit/service/StudyRecruitService.java
+++ b/src/main/java/com/studit/backend/domain/recruit/service/StudyRecruitService.java
@@ -9,16 +9,19 @@ import com.studit.backend.domain.recruit.entity.StudyRecruit;
 import com.studit.backend.domain.recruit.entity.StudyRegister;
 import com.studit.backend.domain.recruit.repository.StudyRecruitRepository;
 import com.studit.backend.domain.recruit.repository.StudyRegisterRepository;
+import com.studit.backend.domain.room.service.StudyRoomService;
 import com.studit.backend.domain.user.entity.User;
 import com.studit.backend.domain.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.List;
 
@@ -28,12 +31,48 @@ public class StudyRecruitService {
 
     private final StudyRecruitRepository studyRecruitRepository;
     private final StudyRegisterRepository studyRegisterRepository;
+    private final StudyRoomService studyRoomService;
     private final UserRepository userRepository;
+    private final TaskScheduler taskScheduler;
+
+    // 모집 종료 시 스터디룸 자동 생성 예약
+    @Transactional
+    public void scheduleCreateRoom(Long recruitId) {
+        StudyRecruit recruit = studyRecruitRepository.findById(recruitId)
+                .orElseThrow(() -> new EntityNotFoundException("Recruit not found"));
+
+        LocalDateTime recruitEndAt = recruit.getRecruitEndAt();
+
+        // 모집 종료 시간이 현재보다 이전이면 실행하지 않음
+        if (recruitEndAt.isBefore(LocalDateTime.now())) {
+            return;
+        }
+
+        // 모집 종료 시각에 스터디룸 생성 예약
+        taskScheduler.schedule(() -> closeRecruitAndCreateRoom(recruit.getId()),
+                java.util.Date.from(recruitEndAt.atZone(ZoneId.systemDefault()).toInstant()));
+    }
+
+    // 모집이 종료되었을 때 실행되는 메서드
+    @Transactional
+    public void closeRecruitAndCreateRoom(Long recruitId) {
+        StudyRecruit recruit = studyRecruitRepository.findById(recruitId)
+                .orElseThrow(() -> new EntityNotFoundException("Recruit not found"));
+
+        // 모집 상태를 완료로 변경
+        recruit.setStatus(RecruitStatus.COMPLETED);
+        studyRecruitRepository.save(recruit);
+
+        // 모집이 진행중인지 다시 확인 (변경 가능성 있음)
+        if (recruit.getStatus() == RecruitStatus.ACTIVE) {
+            studyRoomService.createRoom(recruit);
+        }
+    }
 
     // TODO: pointService 에서 구현될 수 있도록 수정 (실제 차감 + 로그)
     // 스터디 모집글 생성
     @Transactional
-    public void createRecruit(StudyRecruitRequest.Create request, Long leaderId) {
+    public Long createRecruit(StudyRecruitRequest.Create request, Long leaderId) {
 
         // 모집자 정보 가져오기
         User leader = userRepository.findById(leaderId)
@@ -47,7 +86,7 @@ public class StudyRecruitService {
         leader.deductPoint(request.getDeposit());
 
         // 모집글 생성
-        StudyRecruit studyRecruit = StudyRecruit.builder()
+        StudyRecruit recruit = StudyRecruit.builder()
                 .leader(leader)
                 .title(request.getTitle())
                 .description(request.getDescription())
@@ -61,7 +100,18 @@ public class StudyRecruitService {
                 .recruitEndAt(request.getRecruitEndAt())
                 .build();
 
-        studyRecruitRepository.save(studyRecruit);
+        Long recruitId = studyRecruitRepository.save(recruit).getId();
+
+        // 모집장을 자동 가입 처리
+        StudyRegister register = StudyRegister.builder()
+                .studyRecruit(recruit)
+                .user(leader)
+                .status(RegisterStatus.REGISTER)
+                .build();
+
+        studyRegisterRepository.save(register);
+
+        return recruitId;
     }
 
     // 스터디 모집글 목록 조회
@@ -117,51 +167,51 @@ public class StudyRecruitService {
 
     // 스터디 모집글 상세 조회
     public StudyRecruitResponse.Detail getDetailRecruit(Long recruitId) {
-        StudyRecruit studyRecruit = studyRecruitRepository.findById(recruitId)
+        StudyRecruit recruit = studyRecruitRepository.findById(recruitId)
                 .orElseThrow((() -> new EntityNotFoundException("Recruit not found")));
 
         return StudyRecruitResponse.Detail.builder()
-                .recruitId(studyRecruit.getId())
-                .leaderId(studyRecruit.getLeader().getId())
-                .leaderNickname(studyRecruit.getLeader().getNickname())
-                .title(studyRecruit.getTitle())
-                .description(studyRecruit.getDescription())
-                .category(studyRecruit.getCategory().name())
-                .tags(Arrays.asList(studyRecruit.getTags().split(",")))
-                .goalTime(studyRecruit.getGoalTime())
-                .deposit(studyRecruit.getDeposit())
-                .studyStartAt(studyRecruit.getStudyStartAt())
-                .studyEndAt(studyRecruit.getStudyEndAt())
-                .recruitEndAt(studyRecruit.getRecruitEndAt())
-                .currentMembers(studyRegisterRepository.countByStudyRecruitAndStatus(studyRecruit, RegisterStatus.REGISTER))
-                .maxMembers(studyRecruit.getMaxMembers())
-                .status(studyRecruit.getStatus().name())
+                .recruitId(recruit.getId())
+                .leaderId(recruit.getLeader().getId())
+                .leaderNickname(recruit.getLeader().getNickname())
+                .title(recruit.getTitle())
+                .description(recruit.getDescription())
+                .category(recruit.getCategory().name())
+                .tags(Arrays.asList(recruit.getTags().split(",")))
+                .goalTime(recruit.getGoalTime())
+                .deposit(recruit.getDeposit())
+                .studyStartAt(recruit.getStudyStartAt())
+                .studyEndAt(recruit.getStudyEndAt())
+                .recruitEndAt(recruit.getRecruitEndAt())
+                .currentMembers(studyRegisterRepository.countByStudyRecruitAndStatus(recruit, RegisterStatus.REGISTER))
+                .maxMembers(recruit.getMaxMembers())
+                .status(recruit.getStatus().name())
                 .build();
     }
 
     // 스터디 모집글 수정
     public void updateRecruit(Long recruitId, StudyRecruitRequest.Update request, Long userId) {
-        StudyRecruit studyRecruit = studyRecruitRepository.findById(recruitId)
+        StudyRecruit recruit = studyRecruitRepository.findById(recruitId)
                 .orElseThrow(() -> new EntityNotFoundException("Recruit not found"));
 
         // 모집장이 맞는지 확인
-        if (!studyRecruit.getLeader().getId().equals(userId)) {
+        if (!recruit.getLeader().getId().equals(userId)) {
             throw new RuntimeException("수정 권한이 없습니다.");
         }
 
-        studyRecruit.update(request);
-        studyRecruitRepository.save(studyRecruit);
+        recruit.update(request);
+        studyRecruitRepository.save(recruit);
     }
 
     // TODO: pointService 에서 구현될 수 있도록 수정 (실제 추가 + 로그)
     // 스터디 모집글 삭제
     @Transactional
     public void deleteRecruit(Long recruitId, Long userId) {
-        StudyRecruit studyRecruit = studyRecruitRepository.findById(recruitId)
+        StudyRecruit recruit = studyRecruitRepository.findById(recruitId)
                 .orElseThrow(() -> new EntityNotFoundException("Recruit not found"));
 
         // 모집장이 맞는지 확인
-        if (!studyRecruit.getLeader().getId().equals(userId)) {
+        if (!recruit.getLeader().getId().equals(userId)) {
             throw new RuntimeException("삭제 권한이 없습니다.");
         }
 
@@ -169,27 +219,27 @@ public class StudyRecruitService {
                 .orElseThrow(() -> new EntityNotFoundException("User not found"));
 
         // 모집자의 포인트 환불
-        leader.addPoint(studyRecruit.getDeposit());
+        leader.addPoint(recruit.getDeposit());
 
         // 가입자들의 포인트 환불
-        List<StudyRegister> studyRegisters = studyRegisterRepository.findByStudyRecruit(studyRecruit);
+        List<StudyRegister> studyRegisters = studyRegisterRepository.findByStudyRecruit(recruit);
         for (StudyRegister register : studyRegisters) {
             User user = register.getUser();
-            user.addPoint(studyRecruit.getDeposit());
+            user.addPoint(recruit.getDeposit());
         }
 
         // 모집자의 예치금 환불 처리 (pointService 사용)
-//        User leader = studyRecruit.getLeader();
-//        pointService.refundDeposit(leader.getId(), studyRecruit.getDeposit());
+//        User leader = recruit.getLeader();
+//        pointService.refundDeposit(leader.getId(), recruit.getDeposit());
 
         // 가입자들의 예치금 환불 처리 (pointService 사용)
-//        List<StudyRegister> studyRegisters = studyRegisterRepository.findByStudyRecruit(studyRecruit);
+//        List<StudyRegister> studyRegisters = studyRegisterRepository.findByStudyRecruit(recruit);
 //        for (StudyRegister register : studyRegisters) {
 //            User user = register.getUser();
-//            pointService.refundDeposit(user.getId(), studyRecruit.getDeposit());
+//            pointService.refundDeposit(user.getId(), recruit.getDeposit());
 //        }
 
-        studyRecruitRepository.delete(studyRecruit);
+        studyRecruitRepository.delete(recruit);
     }
 
     // TODO: pointService 에서 구현될 수 있도록 수정 (실제 차감 + 로그)
@@ -197,7 +247,7 @@ public class StudyRecruitService {
     @Transactional
     public void studyRegister(Long recruitId, Long userId) {
         // 모집글 조회
-        StudyRecruit studyRecruit = studyRecruitRepository.findById(recruitId)
+        StudyRecruit recruit = studyRecruitRepository.findById(recruitId)
                 .orElseThrow(() -> new EntityNotFoundException("Recruit not found"));
 
         // 사용자 조회
@@ -205,15 +255,32 @@ public class StudyRecruitService {
                 .orElseThrow(() -> new EntityNotFoundException("User not found"));
 
         // 가입자가 가진 포인트가 예치금보다 적으면 예외 발생
-        if (user.getPoint() < studyRecruit.getDeposit()) {
+        if (user.getPoint() < recruit.getDeposit()) {
             throw new IllegalArgumentException("포인트가 부족합니다.");
         }
         // 가입자의 포인트 차감
-        user.deductPoint(studyRecruit.getDeposit());
+        user.deductPoint(recruit.getDeposit());
+
+        // 최대 인원수보다 더 가입할 수 없음
+        int currentMembers = studyRegisterRepository.countByStudyRecruitAndStatus(recruit, RegisterStatus.REGISTER);
+        if (currentMembers >= recruit.getMaxMembers()) {
+            throw new IllegalStateException("최대 인원 수를 초과하여 가입할 수 없습니다.");
+        }
+
+        // 모집장은 자신의 모집에 가입할 수 없음
+        if (recruit.getLeader().equals(user)) {
+            throw new IllegalStateException("모집장은 자신의 모집에 가입할 수 없습니다.");
+        }
+
+        // 중복 가입 방지
+        boolean alreadyRegistered = studyRegisterRepository.existsByStudyRecruitAndUser(recruit, user);
+        if (alreadyRegistered) {
+            throw new IllegalStateException("이미 가입한 스터디입니다.");
+        }
 
         // 스터디 가입 정보 저장
         StudyRegister studyRegister = StudyRegister.builder()
-                .studyRecruit(studyRecruit)
+                .studyRecruit(recruit)
                 .user(user)
                 .build();
 
@@ -228,16 +295,16 @@ public class StudyRecruitService {
         StudyRegister studyRegister = studyRegisterRepository.findByStudyRecruitIdAndUserId(recruitId, userId)
                 .orElseThrow(() -> new IllegalStateException("가입한 스터디가 아닙니다."));
 
-        StudyRecruit studyRecruit = studyRegister.getStudyRecruit();
+        StudyRecruit recruit = studyRegister.getStudyRecruit();
         User user = studyRegister.getUser();
 
         // 모집 기간이 끝났다면 가입 철회 불가
-        if (LocalDateTime.now().isAfter(studyRecruit.getRecruitEndAt())) {
+        if (LocalDateTime.now().isAfter(recruit.getRecruitEndAt())) {
             throw new IllegalStateException("모집이 종료되어 가입을 철회할 수 없습니다.");
         }
 
         // 모집 기간이 끝나지 않았다면 포인트 환불
-        user.addPoint(studyRecruit.getDeposit());
+        user.addPoint(recruit.getDeposit());
 
         studyRegisterRepository.delete(studyRegister);
     }

--- a/src/main/java/com/studit/backend/domain/room/MemberStatus.java
+++ b/src/main/java/com/studit/backend/domain/room/MemberStatus.java
@@ -1,0 +1,6 @@
+package com.studit.backend.domain.room;
+
+public enum MemberStatus {
+    LEADER, // 스터디장
+    MEMBER  // 스터디원
+}

--- a/src/main/java/com/studit/backend/domain/room/RoomStatus.java
+++ b/src/main/java/com/studit/backend/domain/room/RoomStatus.java
@@ -1,0 +1,7 @@
+package com.studit.backend.domain.room;
+
+public enum RoomStatus {
+    ACTIVE, // 진행중
+    DELETED, // 삭제
+    COMPLETED // 완료
+}

--- a/src/main/java/com/studit/backend/domain/room/controller/StudyRoomController.java
+++ b/src/main/java/com/studit/backend/domain/room/controller/StudyRoomController.java
@@ -1,0 +1,16 @@
+package com.studit.backend.domain.room.controller;
+
+import com.studit.backend.domain.room.service.StudyRoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/rooms")
+public class StudyRoomController {
+
+    private final StudyRoomService studyRoomService;
+
+
+}

--- a/src/main/java/com/studit/backend/domain/room/entity/StudyMember.java
+++ b/src/main/java/com/studit/backend/domain/room/entity/StudyMember.java
@@ -1,0 +1,35 @@
+package com.studit.backend.domain.room.entity;
+
+import com.studit.backend.domain.room.MemberStatus;
+import com.studit.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "study_members")
+public class StudyMember {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id; // 멤버 ID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private StudyRoom studyRoom; // 스터디룸
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user; // 사용자 정보
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private MemberStatus status; // 멤버 상태 (LEADER, MEMBER)
+
+    @Column(name = "deposit", nullable = false, updatable = false)
+    private Integer deposit; // 멤버가 납부한 예치금
+}

--- a/src/main/java/com/studit/backend/domain/room/entity/StudyRoom.java
+++ b/src/main/java/com/studit/backend/domain/room/entity/StudyRoom.java
@@ -1,0 +1,70 @@
+package com.studit.backend.domain.room.entity;
+
+import com.studit.backend.domain.recruit.StudyCategory;
+import com.studit.backend.domain.room.RoomStatus;
+import com.studit.backend.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "study_rooms")
+public class StudyRoom {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "room_id")
+    private Long id; // 스터디룸 ID
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "leader_id", nullable = false)
+    private User leader; // 스터디장 ID
+
+    @Column(name = "title", nullable = false, length = 255)
+    private String title; // 스터디명
+
+    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
+    private String description; // 스터디 설명
+
+    @Column(name = "tags", length = 255)
+    private String tags; // 태그 (쉼표로 구분)
+
+    @Column(name = "category", nullable = false, updatable = false)
+    private StudyCategory category; // 카테고리
+
+    @Column(name = "goal_time", nullable = false, updatable = false)
+    private Integer goalTime; // 총 목표시간
+
+    @Column(name = "deposit", nullable = false, updatable = false)
+    private Integer deposit; // 예치금
+
+    @Column(name = "study_start_at", nullable = false, updatable = false)
+    private LocalDateTime studyStartAt; // 스터디 시작일 (모집 종료 시각과 동일)
+
+    @Column(name = "study_end_at", nullable = false, updatable = false)
+    private LocalDateTime studyEndAt; // 스터디 종료일
+
+    @Column(name = "notice_content", columnDefinition = "TEXT")
+    private String noticeContent; // 공지 내용
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private RoomStatus status = RoomStatus.ACTIVE; // 스터디룸 상태 (ACTIVE, DELETED, COMPLETED)
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt; // 최종 수정일
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    @OneToMany(mappedBy = "studyRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<StudyMember> members;
+}

--- a/src/main/java/com/studit/backend/domain/room/repository/StudyMemberRepository.java
+++ b/src/main/java/com/studit/backend/domain/room/repository/StudyMemberRepository.java
@@ -1,0 +1,9 @@
+package com.studit.backend.domain.room.repository;
+
+import com.studit.backend.domain.room.entity.StudyMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> {
+}

--- a/src/main/java/com/studit/backend/domain/room/repository/StudyRoomRepository.java
+++ b/src/main/java/com/studit/backend/domain/room/repository/StudyRoomRepository.java
@@ -1,0 +1,9 @@
+package com.studit.backend.domain.room.repository;
+
+import com.studit.backend.domain.room.entity.StudyRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudyRoomRepository extends JpaRepository<StudyRoom, Long> {
+}

--- a/src/main/java/com/studit/backend/domain/room/service/StudyRoomService.java
+++ b/src/main/java/com/studit/backend/domain/room/service/StudyRoomService.java
@@ -1,0 +1,82 @@
+package com.studit.backend.domain.room.service;
+
+import com.studit.backend.domain.recruit.RecruitStatus;
+import com.studit.backend.domain.recruit.entity.StudyRecruit;
+import com.studit.backend.domain.recruit.entity.StudyRegister;
+import com.studit.backend.domain.recruit.repository.StudyRecruitRepository;
+import com.studit.backend.domain.room.MemberStatus;
+import com.studit.backend.domain.room.RoomStatus;
+import com.studit.backend.domain.room.entity.StudyMember;
+import com.studit.backend.domain.room.entity.StudyRoom;
+import com.studit.backend.domain.room.repository.StudyMemberRepository;
+import com.studit.backend.domain.room.repository.StudyRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StudyRoomService {
+
+    private final StudyRecruitRepository studyRecruitRepository;
+    private final StudyRoomRepository studyRoomRepository;
+    private final StudyMemberRepository studyMemberRepository;
+
+    // 스터디룸 생성
+    @Transactional
+    public void createRoom(StudyRecruit recruit) {
+        // 모집 상태 확인
+        if (recruit.getStatus() != RecruitStatus.ACTIVE) {
+            throw new IllegalStateException("이미 종료된 모집입니다.");
+        }
+
+        // 모집장을 제외한 가입자가 있어야 함
+        List<StudyRegister> registerMembers = recruit.getStudyRegisters()
+                .stream()
+                .filter(register -> !register.getUser().equals(recruit.getLeader()))
+                .toList();
+
+        if (registerMembers.isEmpty()) {
+            throw new IllegalStateException("가입자가 없어 스터디룸을 생성할 수 없습니다.");
+        }
+
+        // 스터디룸 생성
+        StudyRoom studyRoom = StudyRoom.builder()
+                .leader(recruit.getLeader()) // 모집의 리더를 스터디장으로 설정
+                .title(recruit.getTitle())
+                .description(recruit.getDescription())
+                .tags(recruit.getTags())
+                .category(recruit.getCategory())
+                .goalTime(recruit.getGoalTime())
+                .deposit(recruit.getDeposit())
+                .studyStartAt(recruit.getRecruitEndAt()) // 모집 종료 시각 = 스터디 시작일
+                .studyEndAt(recruit.getStudyEndAt())
+                .status(RoomStatus.ACTIVE)
+                .build();
+
+        // 스터디멤버 생성
+        List<StudyMember> studyMembers = new java.util.ArrayList<>(registerMembers.stream()
+                .map(register -> StudyMember.builder()
+                        .studyRoom(studyRoom)
+                        .user(register.getUser())
+                        .status(MemberStatus.MEMBER)
+                        .deposit(recruit.getDeposit())
+                        .build())
+                .toList());
+
+        // 모집장도 스터디장으로 추가
+        studyMembers.add(
+                StudyMember.builder()
+                        .studyRoom(studyRoom)
+                        .user(recruit.getLeader())
+                        .status(MemberStatus.LEADER)
+                        .deposit(recruit.getDeposit())
+                        .build()
+        );
+
+        studyMemberRepository.saveAll(studyMembers);
+        studyRoomRepository.save(studyRoom);
+    }
+}

--- a/src/main/java/com/studit/backend/global/config/TaskSchedulerConfig.java
+++ b/src/main/java/com/studit/backend/global/config/TaskSchedulerConfig.java
@@ -1,0 +1,19 @@
+package com.studit.backend.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+@EnableAsync
+public class TaskSchedulerConfig {
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(5); // 동시에 실행될 스레드 개수
+        scheduler.setThreadNamePrefix("study-room-scheduler-");
+        scheduler.initialize();
+        return scheduler;
+    }
+}


### PR DESCRIPTION
### 변경 사항
- [X] 신규 기능 추가 
- [ ] 버그 수정 
- [ ] 리펙토링
- [ ] 테스트 
- [ ] 문서 업데이트 
- [ ] 기타

### 작업 내역
- 모집글이 생성될 때 모집종료시점에 스터디룸이 자동으로 생성될 수 있도록 예약 설정
- 스터디모집 정보를 토대로 스터디룸과 스터디멤버 생성 (TaskScheduler를 이용하여 모집이 종료되는 시점에 자동으로 생성)
- 모집이 종료되면 스터디모집의 상태가 ACTIVE -> COMPLETED 변경
- 스터디 가입시 예외처리 (최대 인원 수보다 가입 X, 모집장은 자신의 모집에 가입 X, 중복 가입 X)

### 테스트
- [ ] API 테스트
- [ ] 테스트 코드 작성

## 문제 및 해결
X

## 다음 진행사항
- 스터디룸 조회, 수정, 삭제

## 참고
Issue: 14

- 스터디멤버 상태에서 기존 LEADER, MEMBER, BLACK 에서 BLACK 삭제
- 프론트분들과 상의 후 공지사항은 스터디룸마다 하나만 가질 수 있도록 변경 -> 공지사항 테이블 삭제, 스터디룸 테이블의 공지사항 컬럼 추가