### PR TITLE
스터디룸 목록 조회 (검색, 필터링), 스터디룸 상세 조회, 스터디룸 수정, 삭제 기능 구현

### DIFF
--- a/src/main/java/com/studit/backend/domain/recruit/controller/StudyRecruitController.java
+++ b/src/main/java/com/studit/backend/domain/recruit/controller/StudyRecruitController.java
@@ -23,7 +23,7 @@ public class StudyRecruitController {
 
     // 스터디 모집글 생성
     @PostMapping
-    public ResponseEntity<?> createRecruit(
+    public ResponseEntity<String> createRecruit(
             @RequestHeader("Authorization") String token,
             @Validated @RequestBody StudyRecruitRequest.Create request
     ) {
@@ -40,7 +40,7 @@ public class StudyRecruitController {
 
     // 스터디 모집글 목록 조회
     @GetMapping
-    public ResponseEntity<?> getAllRecruits(@RequestParam(defaultValue = "0") int page) {
+    public ResponseEntity<Page<StudyRecruitResponse.Summary>> getAllRecruits(@RequestParam(defaultValue = "0") int page) {
         // 한 페이지당 5개
         int pageSize = 5;
 
@@ -53,7 +53,7 @@ public class StudyRecruitController {
 
     // 스터디 모집글 목록 조회 (검색, 필터링 적용)
     @GetMapping("/search")
-    public ResponseEntity<?> getSearchRecruits(
+    public ResponseEntity<Page<StudyRecruitResponse.Summary>> getSearchRecruits(
             @RequestParam(required = false) String title,
             @RequestParam(required = false) StudyCategory category,
             @RequestParam(required = false) Integer minDeposit,
@@ -75,7 +75,7 @@ public class StudyRecruitController {
 
     // 스터디 모집글 상세 조회
     @GetMapping("/{recruitId}")
-    public ResponseEntity<?> getDetailRecruit(@PathVariable Long recruitId) {
+    public ResponseEntity<StudyRecruitResponse.Detail> getDetailRecruit(@PathVariable Long recruitId) {
         StudyRecruitResponse.Detail recruit = studyRecruitService.getDetailRecruit(recruitId);
 
         return ResponseEntity.ok(recruit);
@@ -83,7 +83,7 @@ public class StudyRecruitController {
 
     // 스터디 모집글 수정
     @PutMapping("/{recruitId}")
-    public ResponseEntity<?> updateRecruit(
+    public ResponseEntity<String> updateRecruit(
             @PathVariable Long recruitId,
             @RequestHeader("Authorization") String token,
             @Validated @RequestBody StudyRecruitRequest.Update request) {
@@ -97,7 +97,7 @@ public class StudyRecruitController {
 
     // 스터디 모집글 삭제
     @DeleteMapping("/{recruitId}")
-    public ResponseEntity<?> deleteRecruit(
+    public ResponseEntity<String> deleteRecruit(
             @PathVariable Long recruitId,
             @RequestHeader("Authorization") String token) {
         // JWT 에서 userId 추출
@@ -110,7 +110,7 @@ public class StudyRecruitController {
 
     // 스터디 가입
     @PostMapping("/{recruitId}/registers")
-    public ResponseEntity<?> studyRegister(
+    public ResponseEntity<String> studyRegister(
             @PathVariable Long recruitId,
             @RequestHeader("Authorization") String token) {
         // JWT 에서 userId 추출
@@ -123,7 +123,7 @@ public class StudyRecruitController {
 
     // 스터디 가입 철회
     @DeleteMapping("/{recruitId}/registers")
-    public ResponseEntity<?> withdrawRegister(
+    public ResponseEntity<String> withdrawRegister(
             @PathVariable Long recruitId,
             @RequestHeader("Authorization") String token) {
         // JWT 에서 userId 추출

--- a/src/main/java/com/studit/backend/domain/room/controller/StudyRoomController.java
+++ b/src/main/java/com/studit/backend/domain/room/controller/StudyRoomController.java
@@ -1,5 +1,6 @@
 package com.studit.backend.domain.room.controller;
 
+import com.studit.backend.domain.recruit.StudyCategory;
 import com.studit.backend.domain.room.dto.StudyRoomResponse;
 import com.studit.backend.domain.room.service.StudyRoomService;
 import lombok.RequiredArgsConstructor;
@@ -30,5 +31,27 @@ public class StudyRoomController {
         Page<StudyRoomResponse.Summary> rooms = studyRoomService.getAllRooms(pageable);
 
         return ResponseEntity.ok(rooms);
+    }
+
+    // 스터디룸 목록 조회 (검색, 필터링 적용)
+    @GetMapping("/search")
+    public ResponseEntity<?> getSearchRooms(
+            @RequestParam(required = false) String title,
+            @RequestParam(required = false) StudyCategory category,
+            @RequestParam(required = false) Integer minDeposit,
+            @RequestParam(required = false) Integer maxDeposit,
+            @RequestParam(required = false) Integer minGoalTime,
+            @RequestParam(required = false) Integer maxGoalTime,
+            @RequestParam(defaultValue = "0") int page
+    ) {
+        // 한 페이지당 5개
+        int pageSize = 5;
+
+        Pageable pageable = PageRequest.of(page, pageSize);
+
+        Page<StudyRoomResponse.Summary> searchRooms = studyRoomService.getSearchRooms(
+                title, category, minDeposit, maxDeposit, minGoalTime, maxGoalTime, pageable);
+
+        return ResponseEntity.ok(searchRooms);
     }
 }

--- a/src/main/java/com/studit/backend/domain/room/controller/StudyRoomController.java
+++ b/src/main/java/com/studit/backend/domain/room/controller/StudyRoomController.java
@@ -1,13 +1,16 @@
 package com.studit.backend.domain.room.controller;
 
 import com.studit.backend.domain.recruit.StudyCategory;
+import com.studit.backend.domain.room.dto.StudyRoomRequest;
 import com.studit.backend.domain.room.dto.StudyRoomResponse;
 import com.studit.backend.domain.room.service.StudyRoomService;
+import com.studit.backend.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class StudyRoomController {
 
     private final StudyRoomService studyRoomService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     // 스터디룸 목록 조회
     @GetMapping
@@ -58,5 +62,32 @@ public class StudyRoomController {
         StudyRoomResponse.Detail studyRoom = studyRoomService.getDetailRoom(roomId);
 
         return ResponseEntity.ok(studyRoom);
+    }
+
+    // 스터디룸 수정 (제목, 설명, 태그 수정 가능)
+    @PutMapping("/{roomId}")
+    public ResponseEntity<?> updateRoom(
+            @PathVariable Long roomId,
+            @RequestHeader("Authorization") String token,
+            @Validated @RequestBody StudyRoomRequest.Update request) {
+        // JWT 에서 userId 추출
+        Long userId = jwtTokenProvider.getUserIdFromToken(token);
+
+        studyRoomService.updateRoom(roomId, request, userId);
+
+        return ResponseEntity.ok("스터디룸이 수정되었습니다.");
+    }
+
+    // 스터디룸 삭제
+    @DeleteMapping("/{roomId}")
+    public ResponseEntity<?> deleteRoom(
+            @PathVariable Long roomId,
+            @RequestHeader("Authorization") String token) {
+        // JWT 에서 userId 추출
+        Long userId = jwtTokenProvider.getUserIdFromToken(token);
+
+        studyRoomService.deleteRoom(roomId, userId);
+
+        return ResponseEntity.ok("스터디룸이 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/studit/backend/domain/room/controller/StudyRoomController.java
+++ b/src/main/java/com/studit/backend/domain/room/controller/StudyRoomController.java
@@ -1,8 +1,15 @@
 package com.studit.backend.domain.room.controller;
 
+import com.studit.backend.domain.room.dto.StudyRoomResponse;
 import com.studit.backend.domain.room.service.StudyRoomService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -12,5 +19,16 @@ public class StudyRoomController {
 
     private final StudyRoomService studyRoomService;
 
+    // 스터디룸 목록 조회
+    @GetMapping
+    public ResponseEntity<?> getAllRooms(@RequestParam(defaultValue = "0") int page) {
+        // 한 페이지당 5개
+        int pageSize = 5;
 
+        Pageable pageable = PageRequest.of(page, pageSize);
+
+        Page<StudyRoomResponse.Summary> rooms = studyRoomService.getAllRooms(pageable);
+
+        return ResponseEntity.ok(rooms);
+    }
 }

--- a/src/main/java/com/studit/backend/domain/room/controller/StudyRoomController.java
+++ b/src/main/java/com/studit/backend/domain/room/controller/StudyRoomController.java
@@ -23,7 +23,7 @@ public class StudyRoomController {
 
     // 스터디룸 목록 조회
     @GetMapping
-    public ResponseEntity<?> getAllRooms(@RequestParam(defaultValue = "0") int page) {
+    public ResponseEntity<Page<StudyRoomResponse.Summary>> getAllRooms(@RequestParam(defaultValue = "0") int page) {
         // 한 페이지당 5개
         int pageSize = 5;
 
@@ -36,7 +36,7 @@ public class StudyRoomController {
 
     // 스터디룸 목록 조회 (검색, 필터링 적용)
     @GetMapping("/search")
-    public ResponseEntity<?> getSearchRooms(
+    public ResponseEntity<Page<StudyRoomResponse.Summary>> getSearchRooms(
             @RequestParam(required = false) String title,
             @RequestParam(required = false) StudyCategory category,
             @RequestParam(required = false) Integer minDeposit,
@@ -58,7 +58,7 @@ public class StudyRoomController {
 
     // 스터디룸 상세 조회
     @GetMapping("/{roomId}")
-    public ResponseEntity<?> getDetailRoom(@PathVariable Long roomId) {
+    public ResponseEntity<StudyRoomResponse.Detail> getDetailRoom(@PathVariable Long roomId) {
         StudyRoomResponse.Detail studyRoom = studyRoomService.getDetailRoom(roomId);
 
         return ResponseEntity.ok(studyRoom);
@@ -66,7 +66,7 @@ public class StudyRoomController {
 
     // 스터디룸 수정 (제목, 설명, 태그 수정 가능)
     @PutMapping("/{roomId}")
-    public ResponseEntity<?> updateRoom(
+    public ResponseEntity<String> updateRoom(
             @PathVariable Long roomId,
             @RequestHeader("Authorization") String token,
             @Validated @RequestBody StudyRoomRequest.Update request) {
@@ -80,7 +80,7 @@ public class StudyRoomController {
 
     // 스터디룸 삭제
     @DeleteMapping("/{roomId}")
-    public ResponseEntity<?> deleteRoom(
+    public ResponseEntity<String> deleteRoom(
             @PathVariable Long roomId,
             @RequestHeader("Authorization") String token) {
         // JWT 에서 userId 추출

--- a/src/main/java/com/studit/backend/domain/room/controller/StudyRoomController.java
+++ b/src/main/java/com/studit/backend/domain/room/controller/StudyRoomController.java
@@ -8,10 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -53,5 +50,13 @@ public class StudyRoomController {
                 title, category, minDeposit, maxDeposit, minGoalTime, maxGoalTime, pageable);
 
         return ResponseEntity.ok(searchRooms);
+    }
+
+    // 스터디룸 상세 조회
+    @GetMapping("/{roomId}")
+    public ResponseEntity<?> getDetailRoom(@PathVariable Long roomId) {
+        StudyRoomResponse.Detail studyRoom = studyRoomService.getDetailRoom(roomId);
+
+        return ResponseEntity.ok(studyRoom);
     }
 }

--- a/src/main/java/com/studit/backend/domain/room/dto/StudyRoomRequest.java
+++ b/src/main/java/com/studit/backend/domain/room/dto/StudyRoomRequest.java
@@ -1,0 +1,4 @@
+package com.studit.backend.domain.room.dto;
+
+public class StudyRoomRequest {
+}

--- a/src/main/java/com/studit/backend/domain/room/dto/StudyRoomRequest.java
+++ b/src/main/java/com/studit/backend/domain/room/dto/StudyRoomRequest.java
@@ -1,4 +1,19 @@
 package com.studit.backend.domain.room.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+import java.util.List;
+
 public class StudyRoomRequest {
+    @Data
+    public static class Update {
+        @NotBlank(message = "스터디룸 제목은 필수 입력값입니다.")
+        private String title;
+
+        @NotBlank(message = "스터디룸 설명은 필수 입력값입니다.")
+        private String description;
+
+        private List<String> tags;
+    }
 }

--- a/src/main/java/com/studit/backend/domain/room/dto/StudyRoomResponse.java
+++ b/src/main/java/com/studit/backend/domain/room/dto/StudyRoomResponse.java
@@ -1,0 +1,43 @@
+package com.studit.backend.domain.room.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class StudyRoomResponse {
+
+    @Builder
+    @Data
+    public static class Summary {
+        private Long roomId;
+        private String title;
+        private String category;
+        private List<String> tags;
+        private int goalTime;
+        private int deposit;
+        private LocalDateTime studyStartAt;
+        private LocalDateTime studyEndAt;
+        private int currentMembers;
+        private String status;
+    }
+
+    @Builder
+    @Data
+    public static class Detail {
+        private Long roomId;
+        private Long leaderId;
+        private String leaderNickname;
+        private String title;
+        private String description;
+        private String category;
+        private List<String> tags;
+        private int goalTime;
+        private int deposit;
+        private LocalDateTime studyStartAt;
+        private LocalDateTime studyEndAt;
+        private int currentMembers;
+        private String status;
+    }
+}

--- a/src/main/java/com/studit/backend/domain/room/entity/StudyRoom.java
+++ b/src/main/java/com/studit/backend/domain/room/entity/StudyRoom.java
@@ -66,5 +66,5 @@ public class StudyRoom {
     }
 
     @OneToMany(mappedBy = "studyRoom", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<StudyMember> members;
+    private List<StudyMember> studyMembers;
 }

--- a/src/main/java/com/studit/backend/domain/room/entity/StudyRoom.java
+++ b/src/main/java/com/studit/backend/domain/room/entity/StudyRoom.java
@@ -2,6 +2,7 @@ package com.studit.backend.domain.room.entity;
 
 import com.studit.backend.domain.recruit.StudyCategory;
 import com.studit.backend.domain.room.RoomStatus;
+import com.studit.backend.domain.room.dto.StudyRoomRequest;
 import com.studit.backend.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -67,4 +68,11 @@ public class StudyRoom {
 
     @OneToMany(mappedBy = "studyRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StudyMember> studyMembers;
+
+    // 수정할 데이터만 업데이트하는 메서드
+    public void update(StudyRoomRequest.Update request) {
+        this.title = request.getTitle();
+        this.description = request.getDescription();
+        this.tags = String.join(",", request.getTags());
+    }
 }

--- a/src/main/java/com/studit/backend/domain/room/repository/StudyMemberRepository.java
+++ b/src/main/java/com/studit/backend/domain/room/repository/StudyMemberRepository.java
@@ -1,9 +1,13 @@
 package com.studit.backend.domain.room.repository;
 
 import com.studit.backend.domain.room.entity.StudyMember;
+import com.studit.backend.domain.room.entity.StudyRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> {
+    List<StudyMember> findByStudyRoom(StudyRoom studyRoom);
 }

--- a/src/main/java/com/studit/backend/domain/room/repository/StudyRoomRepository.java
+++ b/src/main/java/com/studit/backend/domain/room/repository/StudyRoomRepository.java
@@ -1,13 +1,32 @@
 package com.studit.backend.domain.room.repository;
 
+import com.studit.backend.domain.recruit.StudyCategory;
 import com.studit.backend.domain.room.RoomStatus;
 import com.studit.backend.domain.room.entity.StudyRoom;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StudyRoomRepository extends JpaRepository<StudyRoom, Long> {
     Page<StudyRoom> findByStatusOrderByStudyStartAtDesc(RoomStatus status, Pageable pageable);
+
+    @Query("SELECT sr FROM StudyRoom sr " +
+            "WHERE sr.status = 'ACTIVE' " + // 스터디룸 상태가 ACTIVE 인 것만 조회
+            "AND (:title IS NULL OR sr.title LIKE %:title% OR sr.tags LIKE %:title%) " +  // tags 포함 검색
+            "AND (:category IS NULL OR sr.category = :category) " +
+            "AND sr.deposit BETWEEN :minDeposit AND :maxDeposit " +
+            "AND sr.goalTime BETWEEN :minGoalTime AND :maxGoalTime")
+    Page<StudyRoom> findByFilters(
+            @Param("title") String title,
+            @Param("category") StudyCategory category,
+            @Param("minDeposit") int minDeposit,
+            @Param("maxDeposit") int maxDeposit,
+            @Param("minGoalTime") int minGoalTime,
+            @Param("maxGoalTime") int maxGoalTime,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/studit/backend/domain/room/repository/StudyRoomRepository.java
+++ b/src/main/java/com/studit/backend/domain/room/repository/StudyRoomRepository.java
@@ -1,9 +1,13 @@
 package com.studit.backend.domain.room.repository;
 
+import com.studit.backend.domain.room.RoomStatus;
 import com.studit.backend.domain.room.entity.StudyRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StudyRoomRepository extends JpaRepository<StudyRoom, Long> {
+    Page<StudyRoom> findByStatusOrderByStudyStartAtDesc(RoomStatus status, Pageable pageable);
 }

--- a/src/main/java/com/studit/backend/domain/room/service/StudyRoomService.java
+++ b/src/main/java/com/studit/backend/domain/room/service/StudyRoomService.java
@@ -1,6 +1,7 @@
 package com.studit.backend.domain.room.service;
 
 import com.studit.backend.domain.recruit.RecruitStatus;
+import com.studit.backend.domain.recruit.StudyCategory;
 import com.studit.backend.domain.recruit.entity.StudyRecruit;
 import com.studit.backend.domain.recruit.entity.StudyRegister;
 import com.studit.backend.domain.recruit.repository.StudyRecruitRepository;
@@ -89,6 +90,35 @@ public class StudyRoomService {
         Page<StudyRoom> rooms = studyRoomRepository.findByStatusOrderByStudyStartAtDesc(RoomStatus.ACTIVE, pageable);
 
         return rooms.map(studyRoom -> StudyRoomResponse.Summary.builder()
+                .roomId(studyRoom.getId())
+                .title(studyRoom.getTitle())
+                .category(studyRoom.getCategory().name())
+                .tags(Arrays.asList(studyRoom.getTags().split(",")))
+                .goalTime(studyRoom.getGoalTime())
+                .deposit(studyRoom.getDeposit())
+                .studyStartAt(studyRoom.getStudyStartAt())
+                .studyEndAt(studyRoom.getStudyEndAt())
+                .currentMembers(studyRoom.getStudyMembers().size())
+                .status(studyRoom.getStatus().name())
+                .build());
+    }
+
+    // 스터디룸 목록 조회 (검색, 필터링 적용)
+    public Page<StudyRoomResponse.Summary> getSearchRooms(
+            String title, StudyCategory category,
+            Integer minDeposit, Integer maxDeposit, Integer minGoalTime, Integer maxGoalTime,
+            Pageable pageable
+    ) {
+        // null 값 방지
+        int minDepositValue = (minDeposit != null) ? minDeposit : 0;
+        int maxDepositValue = (maxDeposit != null) ? maxDeposit : Integer.MAX_VALUE;
+        int minGoalTimeValue = (minGoalTime != null) ? minGoalTime : 0;
+        int maxGoalTimeValue = (maxGoalTime != null) ? maxGoalTime : Integer.MAX_VALUE;
+
+        Page<StudyRoom> searchRooms = studyRoomRepository.findByFilters(
+                title, category, minDepositValue, maxDepositValue, minGoalTimeValue, maxGoalTimeValue, pageable);
+
+        return searchRooms.map(studyRoom -> StudyRoomResponse.Summary.builder()
                 .roomId(studyRoom.getId())
                 .title(studyRoom.getTitle())
                 .category(studyRoom.getCategory().name())

--- a/src/main/java/com/studit/backend/domain/room/service/StudyRoomService.java
+++ b/src/main/java/com/studit/backend/domain/room/service/StudyRoomService.java
@@ -12,6 +12,7 @@ import com.studit.backend.domain.room.entity.StudyMember;
 import com.studit.backend.domain.room.entity.StudyRoom;
 import com.studit.backend.domain.room.repository.StudyMemberRepository;
 import com.studit.backend.domain.room.repository.StudyRoomRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -130,5 +131,27 @@ public class StudyRoomService {
                 .currentMembers(studyRoom.getStudyMembers().size())
                 .status(studyRoom.getStatus().name())
                 .build());
+    }
+
+    // 스터디룸 상세 조회
+    public StudyRoomResponse.Detail getDetailRoom(Long roomId) {
+        StudyRoom studyRoom = studyRoomRepository.findById(roomId)
+                .orElseThrow((() -> new EntityNotFoundException("Room not found")));
+
+        return StudyRoomResponse.Detail.builder()
+                .roomId(studyRoom.getId())
+                .leaderId(studyRoom.getLeader().getId())
+                .leaderNickname(studyRoom.getLeader().getNickname())
+                .title(studyRoom.getTitle())
+                .description(studyRoom.getDescription())
+                .category(studyRoom.getCategory().name())
+                .tags(Arrays.asList(studyRoom.getTags().split(",")))
+                .goalTime(studyRoom.getGoalTime())
+                .deposit(studyRoom.getDeposit())
+                .studyStartAt(studyRoom.getStudyStartAt())
+                .studyEndAt(studyRoom.getStudyEndAt())
+                .currentMembers(studyRoom.getStudyMembers().size())
+                .status(studyRoom.getStatus().name())
+                .build();
     }
 }

--- a/src/main/java/com/studit/backend/domain/room/service/StudyRoomService.java
+++ b/src/main/java/com/studit/backend/domain/room/service/StudyRoomService.java
@@ -6,14 +6,18 @@ import com.studit.backend.domain.recruit.entity.StudyRegister;
 import com.studit.backend.domain.recruit.repository.StudyRecruitRepository;
 import com.studit.backend.domain.room.MemberStatus;
 import com.studit.backend.domain.room.RoomStatus;
+import com.studit.backend.domain.room.dto.StudyRoomResponse;
 import com.studit.backend.domain.room.entity.StudyMember;
 import com.studit.backend.domain.room.entity.StudyRoom;
 import com.studit.backend.domain.room.repository.StudyMemberRepository;
 import com.studit.backend.domain.room.repository.StudyRoomRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Service
@@ -78,5 +82,23 @@ public class StudyRoomService {
 
         studyMemberRepository.saveAll(studyMembers);
         studyRoomRepository.save(studyRoom);
+    }
+
+    // 스터디룸 목록 조회
+    public Page<StudyRoomResponse.Summary> getAllRooms(Pageable pageable) {
+        Page<StudyRoom> rooms = studyRoomRepository.findByStatusOrderByStudyStartAtDesc(RoomStatus.ACTIVE, pageable);
+
+        return rooms.map(studyRoom -> StudyRoomResponse.Summary.builder()
+                .roomId(studyRoom.getId())
+                .title(studyRoom.getTitle())
+                .category(studyRoom.getCategory().name())
+                .tags(Arrays.asList(studyRoom.getTags().split(",")))
+                .goalTime(studyRoom.getGoalTime())
+                .deposit(studyRoom.getDeposit())
+                .studyStartAt(studyRoom.getStudyStartAt())
+                .studyEndAt(studyRoom.getStudyEndAt())
+                .currentMembers(studyRoom.getStudyMembers().size())
+                .status(studyRoom.getStatus().name())
+                .build());
     }
 }

--- a/src/main/java/com/studit/backend/domain/user/entity/User.java
+++ b/src/main/java/com/studit/backend/domain/user/entity/User.java
@@ -61,9 +61,9 @@ public class User {
 //    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
 //    private List<pointLog.PointLog> pointLogs;
 
- //스터디참여자관리(1:N)
+    // 스터디멤버
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private List<StudyMember> studyPartcpntMgntList;
+    private List<StudyMember> studyMembers;
 
     public User(Long kakaoId, String nickname, String profileImageUrl, Role role) {
         this.kakaoId = kakaoId;


### PR DESCRIPTION
### 변경 사항
- [X] 신규 기능 추가 
- [ ] 버그 수정 
- [X] 리펙토링
- [ ] 테스트 
- [ ] 문서 업데이트 
- [ ] 기타

### 작업 내역
- 스터디룸 목록이 조회될 때 진행중인 스터디만 노출될 수 있도록 구현
- 필터링을 통해 스터디룸을 검색할 수 있게 구현
- 스터디룸의 상세 정보를 조회할 수 있도록 구현
- 스터디명, 스터디 설명, 스터디 태그 수정할 수 있도록 구현 (스터디장 권한)
- 스터디룸을 삭제할 수 있도록 구현 (스터디장 권한, 스터디장과 스터디원의 예치금 환불)

### 테스트
- [X] API 테스트
- [ ] 테스트 코드 작성

## 문제 및 해결
X

## 다음 진행사항
- 스터디룸 나가기 기능

## 참고
Issue: 14