### PR TITLE
스터디룸 나가기(중도포기), 스터디룸 공지사항 기능 구현

### DIFF
--- a/src/main/java/com/studit/backend/domain/room/controller/StudyRoomController.java
+++ b/src/main/java/com/studit/backend/domain/room/controller/StudyRoomController.java
@@ -90,4 +90,14 @@ public class StudyRoomController {
 
         return ResponseEntity.ok("스터디룸이 삭제되었습니다.");
     }
+
+    // 스터디룸 나가기 (Only 스터디원)
+    @DeleteMapping("/{roomId}/leave")
+    public ResponseEntity<String> leaveRoom(
+            @PathVariable Long roomId,
+            @RequestHeader("Authorization") String token) {
+        Long userId = jwtTokenProvider.getUserIdFromToken(token);
+        studyRoomService.leaveRoom(roomId, userId);
+        return ResponseEntity.ok("스터디룸을 나갔습니다.");
+    }
 }

--- a/src/main/java/com/studit/backend/domain/room/controller/StudyRoomController.java
+++ b/src/main/java/com/studit/backend/domain/room/controller/StudyRoomController.java
@@ -100,4 +100,25 @@ public class StudyRoomController {
         studyRoomService.leaveRoom(roomId, userId);
         return ResponseEntity.ok("스터디룸을 나갔습니다.");
     }
+
+    // 공지사항 작성 또는 수정 (Only 스터디장)
+    @PostMapping("/{roomId}/notices")
+    public ResponseEntity<String> createOrUpdateNotice(
+            @PathVariable Long roomId,
+            @RequestHeader("Authorization") String token,
+            @RequestBody StudyRoomRequest.NoticeContent request) {
+        Long userId = jwtTokenProvider.getUserIdFromToken(token);
+        studyRoomService.createOrUpdateNotice(roomId, userId, request.getContent());
+        return ResponseEntity.ok("공지사항이 저장되었습니다.");
+    }
+
+    // 공지사항 삭제 (Only 스터디장)
+    @DeleteMapping("/{roomId}/notices")
+    public ResponseEntity<String> deleteNotice(
+            @PathVariable Long roomId,
+            @RequestHeader("Authorization") String token) {
+        Long userId = jwtTokenProvider.getUserIdFromToken(token);
+        studyRoomService.deleteNotice(roomId, userId);
+        return ResponseEntity.ok("공지사항이 삭제되었습니다.");
+    }
 }

--- a/src/main/java/com/studit/backend/domain/room/dto/StudyRoomRequest.java
+++ b/src/main/java/com/studit/backend/domain/room/dto/StudyRoomRequest.java
@@ -16,4 +16,9 @@ public class StudyRoomRequest {
 
         private List<String> tags;
     }
+
+    @Data
+    public static class NoticeContent {
+        private String content;
+    }
 }

--- a/src/main/java/com/studit/backend/domain/room/repository/StudyMemberRepository.java
+++ b/src/main/java/com/studit/backend/domain/room/repository/StudyMemberRepository.java
@@ -6,8 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface StudyMemberRepository extends JpaRepository<StudyMember, Long> {
     List<StudyMember> findByStudyRoom(StudyRoom studyRoom);
+    Optional<StudyMember> findByStudyRoomIdAndUserId(Long roomId, Long userId);
 }

--- a/src/main/java/com/studit/backend/domain/room/service/StudyRoomService.java
+++ b/src/main/java/com/studit/backend/domain/room/service/StudyRoomService.java
@@ -218,4 +218,36 @@ public class StudyRoomService {
         // 스터디 멤버 삭제 (예치금 환불 X)
         studyMemberRepository.delete(studyMember);
     }
+
+    // 공지사항 작성 또는 수정 (Only 스터디장)
+    @Transactional
+    public void createOrUpdateNotice(Long roomId, Long userId, String content) {
+        StudyRoom studyRoom = studyRoomRepository.findById(roomId)
+                .orElseThrow(() -> new EntityNotFoundException("StudyRoom not found"));
+
+        // 스터디장이 맞는지 확인
+        if (!studyRoom.getLeader().getId().equals(userId)) {
+            throw new IllegalStateException("스터디장만 공지사항을 작성할 수 있습니다.");
+        }
+
+        // 공지사항 업데이트
+        studyRoom.setNoticeContent(content);
+        studyRoomRepository.save(studyRoom);
+    }
+
+    // 공지사항 삭제 (Only 스터디장)
+    @Transactional
+    public void deleteNotice(Long roomId, Long userId) {
+        StudyRoom studyRoom = studyRoomRepository.findById(roomId)
+                .orElseThrow(() -> new EntityNotFoundException("StudyRoom not found"));
+
+        // 스터디장이 맞는지 확인
+        if (!studyRoom.getLeader().getId().equals(userId)) {
+            throw new IllegalStateException("스터디장만 공지사항을 삭제할 수 있습니다.");
+        }
+
+        // 공지사항 삭제
+        studyRoom.setNoticeContent(null);
+        studyRoomRepository.save(studyRoom);
+    }
 }

--- a/src/main/java/com/studit/backend/domain/room/service/StudyRoomService.java
+++ b/src/main/java/com/studit/backend/domain/room/service/StudyRoomService.java
@@ -200,4 +200,22 @@ public class StudyRoomService {
 
         studyRoomRepository.delete(studyRoom);
     }
+
+    // 스터디룸 나가기 (Only 스터디원)
+    @Transactional
+    public void leaveRoom(Long roomId, Long userId) {
+        StudyRoom studyRoom = studyRoomRepository.findById(roomId)
+                .orElseThrow(() -> new EntityNotFoundException("StudyRoom not found"));
+
+        // 스터디원인지 확인
+        StudyMember studyMember = studyMemberRepository.findByStudyRoomIdAndUserId(roomId, userId)
+                .orElseThrow(() -> new EntityNotFoundException("스터디멤버가 아닙니다."));
+
+        if (studyMember.getStatus() == MemberStatus.LEADER) {
+            throw new IllegalStateException("스터디장은 스터디룸을 나갈 수 없습니다.");
+        }
+
+        // 스터디 멤버 삭제 (예치금 환불 X)
+        studyMemberRepository.delete(studyMember);
+    }
 }


### PR DESCRIPTION
### 변경 사항
- [X] 신규 기능 추가 
- [ ] 버그 수정 
- [ ] 리펙토링
- [ ] 테스트 
- [ ] 문서 업데이트 
- [ ] 기타

### 작업 내역
- 스터디에 참여중인 멤버는 스터디 나가기를 통해 중도포기를 할 수 있음 (예치금 환불 X)
- 스터디장은 공지사항을 등록, 삭제할 수 있음

### 테스트
- [ ] API 테스트
- [ ] 테스트 코드 작성

## 문제 및 해결
X

## 다음 진행사항
X

## 참고
Issue: 14